### PR TITLE
Make message body conversion to UTF-8 more reliable

### DIFF
--- a/astrotrain.gemspec
+++ b/astrotrain.gemspec
@@ -35,10 +35,12 @@ Gem::Specification.new do |s|
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
-  s.add_dependency('mail',        ["~> 2.2.14"])
-  s.add_dependency('i18n',        ["~> 0.4.1"])
-  s.add_dependency('faraday',     ["~> 0.5.0"])
-  s.add_dependency('addressable', ["~> 2.2.4"])
+  s.add_dependency('utf8',            ["~> 0.1.8"])
+  s.add_dependency('mail',            ["~> 2.2.14"])
+  s.add_dependency('i18n',            ["~> 0.4.1"])
+  s.add_dependency('faraday',         ["~> 0.5.0"])
+  s.add_dependency('addressable',     ["~> 2.2.4"])
+  s.add_dependency('charlock_holmes', ["~> 0.6.8"])
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development

--- a/lib/astrotrain.rb
+++ b/lib/astrotrain.rb
@@ -1,6 +1,8 @@
 module Astrotrain
   VERSION = '0.6.0'
 
+  require 'utf8'
+  require 'charlock_holmes'
   require 'addressable/uri'
   require 'faraday'
   require 'astrotrain/attachment'

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -58,13 +58,7 @@ class MessageParsingTest < Test::Unit::TestCase
     msg = astrotrain(:gb2312_encoding_invalid)
     # encoding problem?
     # "Dear Sirs, \r\nWe are given to understand that you are  Manufacturer of  plstic  Bottles\r\nAdd： blah China"
-    s = if Object.const_defined?(:Encoding)
-      # ruby 1.9 tried its best
-      "Dear Sirs, \r\nWe are given to understand that you are  Manufacturer of  plstic  Bottles\r\nAdd\243\272 blah China"
-    else
-      # ruby 1.8 ignores the weird crap
-      "Dear Sirs, \r\nWe are given to understand that you are  Manufacturer of  plstic  Bottles\r\nAdd blah China"
-    end
+    s = "Dear Sirs, \r\nWe are given to understand that you are  Manufacturer of  plstic  Bottles\r\nAdd?? blah China"
     assert_equal s, msg.body
   end
 


### PR DESCRIPTION
This brings in charlock_holmes to attempt to detect the encoding of messages that don't have a charset header set. We also use the utf8 gem to ensure that the output is _always_ valid UTF-8 - even if it means mutating the invalid string to do so.
