### PR TITLE
Ensure decoding of messages with content-type set

### DIFF
--- a/lib/astrotrain/message.rb
+++ b/lib/astrotrain/message.rb
@@ -309,7 +309,7 @@ module Astrotrain
     # Returns converted String.
     def convert_to_utf8(s)
       # If this string is already valid UTF-8 just hand it back
-      if s.as_utf8.valid?
+      if (!@mail.charset || @mail.charset == 'UTF-8') && s.as_utf8.valid?
         s.force_encoding("UTF-8") if s.respond_to?(:force_encoding)
         return s
       end
@@ -322,7 +322,11 @@ module Astrotrain
       # if the encoding was already set or we just detected it AND it's not already
       # set to UTF-8 - try to transcode the body into UTF-8
       if @mail.charset && @mail.charset != 'UTF-8'
-        s = CharlockHolmes::Converter.convert s, @mail.charset, 'UTF-8'
+        if s.size > 0
+          s = CharlockHolmes::Converter.convert s, @mail.charset, 'UTF-8'
+        else
+          s = ""
+        end
       end
 
       # By the time we get here, `s` is either UTF-8 or we need to force it to be

--- a/test/fixtures/iso-2022-jp.txt
+++ b/test/fixtures/iso-2022-jp.txt
@@ -1,0 +1,16 @@
+X-Account-Key: account2
+X-UIDL: Sj!#!TDi"!QpG!!2V>!!
+Return-Path: <yamada@example.jp>
+Message-ID: <49D416F1.8070504@oiax.jp>
+Date: Thu, 02 Apr 2009 10:37:53 +0900
+From: Taro Yamada <yamada@example.jp>
+MIME-Version: 1.0
+To: alpha.all@clubee.jp
+Subject: =?ISO-2022-JP?B?GyRCRWo5RhsoQjA=?=
+Content-Type: text/plain; charset=ISO-2022-JP
+Content-Transfer-Encoding: 7bit
+X-UIDL: Sj!#!TDi"!QpG!!2V>!!
+
+投稿テスト
+--
+yamada@example.jp

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -1,5 +1,4 @@
 # encoding: UTF-8
-require 'nkf'
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 class MessageParsingTest < Test::Unit::TestCase

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+require 'nkf'
 require File.expand_path(File.join(File.dirname(__FILE__), "test_helper"))
 
 class MessageParsingTest < Test::Unit::TestCase
@@ -207,5 +208,11 @@ class MessageParsingTest < Test::Unit::TestCase
         assert_equal "UTF-8", str.encoding.name
       end
     end
+  end
+
+  test "iso 2022 jp encoded subject and body" do
+    msg = astrotrain "iso-2022-jp"
+    assert_mail_utf8 msg
+    assert_equal "投稿テスト\n--\nyamada@example.jp", msg.body
   end
 end


### PR DESCRIPTION
Previously, if a string could be encoded as UTF-8 in a valid manner it was assumed that it was already decoded regardless of specified content-type. This unfortunately meant that for encodings that happened to be encoded in valid UTF-8 characters (like ISO-2022-JP), the message content was never properly decoded.